### PR TITLE
Release 0.9 (Mekhanical Update - Part 3)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "wng-apocrypha",
   "title": "Wrath and Glory - An Abundance of Apocrypha",
   "description": "A module containing the An Abundance of Apocrypha content for Wrath &amp; Glory System.",
-  "version": "0.8",
+  "version": "0.9",
   "compatibility": {
     "minimum": "11",
     "verified": "11.315",
@@ -103,5 +103,5 @@
   ],
   "url": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT",
   "manifest": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/latest/module.json",
-  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/MekhanicalUpdate2/wng-apocrypha.zip"
+  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/MekhanicalUpdate3/wng-apocrypha.zip"
 }


### PR DESCRIPTION
Bumps version 0.8 → 0.9 and points `download` at the new `MekhanicalUpdate3` release tag. The `manifest` URL (the `latest` release) is intentionally **unchanged** so Foundry keeps checking the same location.

Ships the work merged this cycle: all 9 (NYI) archetype stubs closed, accidental duplicates removed, tier/spelling fixes.