### PR TITLE
CI: release workflow + Foundry Package Release API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+# Builds the distributable zip, attaches it to the release, refreshes the
+# moving `latest` manifest, and (if a token is configured) registers the
+# release with the Foundry VTT Package Release API.
+#
+# Trigger either by publishing a GitHub Release, or manually via
+# "Run workflow" (workflow_dispatch) against an existing release tag.
+#
+# Requires repository secret FVTT_RELEASE_TOKEN (the "Package Release Token"
+# from the package's page on foundryvtt.com) for the Foundry API step.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)build and register (e.g. MekhanicalUpdate3)"
+        required: true
+      dry_run:
+        description: "Foundry API dry-run (validate without publishing)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      FVTT_RELEASE_TOKEN: ${{ secrets.FVTT_RELEASE_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          {
+            echo "tag=$TAG"
+            echo "version=$(jq -r '.version' module.json)"
+            echo "minimum=$(jq -r '.compatibility.minimum // ""' module.json)"
+            echo "verified=$(jq -r '.compatibility.verified // ""' module.json)"
+            echo "maximum=$(jq -r '.compatibility.maximum // ""' module.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build module zip
+        run: |
+          mkdir -p dist/wng-apocrypha/packs
+          cp module.json dist/wng-apocrypha/
+          cp -r assets dist/wng-apocrypha/
+          for p in items journals actors; do
+            cp -r "packs/an-abundance-of-apocrypha-$p" dist/wng-apocrypha/packs/
+          done
+          find dist/wng-apocrypha/packs -name "*.db" -delete
+          find dist/wng-apocrypha/packs -type d -name lost -exec rm -rf {} + 2>/dev/null || true
+          (cd dist && zip -qr ../wng-apocrypha.zip wng-apocrypha)
+          ls -la wng-apocrypha.zip
+
+      - name: Attach assets to the release
+        run: gh release upload "${{ steps.meta.outputs.tag }}" module.json wng-apocrypha.zip --clobber --repo "${{ github.repository }}"
+
+      - name: Refresh moving 'latest' manifest
+        run: gh release upload latest module.json --clobber --repo "${{ github.repository }}"
+
+      - name: Register with Foundry Package Release API
+        if: ${{ env.FVTT_RELEASE_TOKEN != '' }}
+        run: |
+          payload=$(jq -n \
+            --arg id "$(jq -r '.id' module.json)" \
+            --argjson dry ${{ inputs.dry_run || false }} \
+            --arg version "${{ steps.meta.outputs.version }}" \
+            --arg manifest "https://github.com/${{ github.repository }}/releases/download/${{ steps.meta.outputs.tag }}/module.json" \
+            --arg notes "https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}" \
+            --arg min "${{ steps.meta.outputs.minimum }}" \
+            --arg verified "${{ steps.meta.outputs.verified }}" \
+            --arg max "${{ steps.meta.outputs.maximum }}" \
+            '{id:$id, "dry-run":$dry, release:{version:$version, manifest:$manifest, notes:$notes, compatibility:{minimum:$min, verified:$verified, maximum:$max}}}')
+          echo "Posting release ${{ steps.meta.outputs.version }} to Foundry (dry-run=${{ inputs.dry_run || false }})"
+          curl -fsSL -X POST "https://foundryvtt.com/_api/packages/release_version/" \
+            -H "Authorization: $FVTT_RELEASE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload"
+
+      - name: Skip Foundry API (no token)
+        if: ${{ env.FVTT_RELEASE_TOKEN == '' }}
+        run: echo "FVTT_RELEASE_TOKEN secret not set — skipped Foundry Package Release API registration."

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ npm run pack     # YAML sources -> LevelDB packs
 Foundry host, Linux, or WSL). After editing, always reload the module in
 Foundry to confirm the compendium loads — see [src/packs/README.md](src/packs/README.md).
 
+### Releasing
+
+`module.json` keeps a **fixed** `manifest` URL pointing at the moving `latest`
+release (`releases/download/latest/module.json`) — never change it, or Foundry
+installs stop seeing updates. The `download` URL points at a versioned release
+tag.
+
+To cut a release: bump `version` (and the `download` tag) in `module.json`, then
+create a GitHub Release on that tag. The [Release workflow](.github/workflows/release.yml)
+then builds `wng-apocrypha.zip`, attaches it plus `module.json` to the release,
+refreshes the `latest` manifest, and — if the repository secret
+`FVTT_RELEASE_TOKEN` (the Package Release Token from the package's
+[foundryvtt.com](https://foundryvtt.com) page) is set — registers the release
+with the Foundry Package Release API. The workflow can also be run manually
+("Run workflow") against an existing tag, with a dry-run option.
+
 ## License
 
 This module's own packaging/code is released under the **MIT License** — see


### PR DESCRIPTION
## What
Adds `.github/workflows/release.yml` to automate releases and register them with the **Foundry Package Release API**.

On `release: published` (or manual `workflow_dispatch` against an existing tag) it:
1. Builds `wng-apocrypha.zip` (`wng-apocrypha/{module.json, assets, packs}`).
2. Attaches `module.json` + the zip to the release.
3. Refreshes the moving **`latest`** manifest (the fixed URL Foundry polls — never changed).
4. If the secret **`FVTT_RELEASE_TOKEN`** is set, POSTs to `https://foundryvtt.com/_api/packages/release_version/` with the version/compatibility from `module.json` and a version-specific `manifest` URL (`releases/download/<tag>/module.json`). Supports a **dry-run** input.

## Setup required (one-time)
- Add the repo secret **`FVTT_RELEASE_TOKEN`** = the *Package Release Token* from the package's page on foundryvtt.com. (Settings → Secrets and variables → Actions.)

## Notes
- The Foundry API step is skipped gracefully if the secret is absent.
- README gained a **Releasing** section documenting the flow and the fixed-manifest rule.