### PR TITLE
CI: show Foundry API error body, trim token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,10 +80,18 @@ jobs:
             --arg max "${{ steps.meta.outputs.maximum }}" \
             '{id:$id, "dry-run":$dry, release:{version:$version, manifest:$manifest, notes:$notes, compatibility:{minimum:$min, verified:$verified, maximum:$max}}}')
           echo "Posting release ${{ steps.meta.outputs.version }} to Foundry (dry-run=${{ inputs.dry_run || false }})"
-          curl -fsSL -X POST "https://foundryvtt.com/_api/packages/release_version/" \
-            -H "Authorization: $FVTT_RELEASE_TOKEN" \
+          # Trim any stray whitespace/newline that may have been pasted into the secret.
+          token=$(printf '%s' "$FVTT_RELEASE_TOKEN" | tr -d '[:space:]')
+          http=$(curl -sS -o resp.json -w '%{http_code}' -X POST "https://foundryvtt.com/_api/packages/release_version/" \
+            -H "Authorization: $token" \
             -H "Content-Type: application/json" \
-            -d "$payload"
+            -d "$payload")
+          echo "HTTP $http"
+          echo "Response:"; cat resp.json; echo
+          if [ "$http" -ge 400 ]; then
+            echo "::error::Foundry Package Release API returned HTTP $http (see response above)."
+            exit 1
+          fi
 
       - name: Skip Foundry API (no token)
         if: ${{ env.FVTT_RELEASE_TOKEN == '' }}


### PR DESCRIPTION
The release workflow's Foundry API step used `curl -fsS`, which **suppresses the response body** on HTTP errors — so the 400 you hit showed no reason.

This captures the HTTP status + response body, **prints them**, trims any stray whitespace/newline from the pasted token (a common paste error), and fails with the actual Foundry message.

Re-run the workflow after merging to see exactly why the 400 happened (most likely `version 0.9 already exists` if you already registered it manually, which is harmless).