### PR TITLE
CI: 'already exists' is a warning, not a failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
           echo "HTTP $http"
           echo "Response:"; cat resp.json; echo
           if [ "$http" -ge 400 ]; then
+            if grep -q "unique_together\|already exists" resp.json; then
+              echo "::warning::This version is already registered on Foundry — nothing to do."
+              exit 0
+            fi
             echo "::error::Foundry Package Release API returned HTTP $http (see response above)."
             exit 1
           fi


### PR DESCRIPTION
Re-running the release for an already-registered version returns HTTP 400 (`unique_together`). That's harmless — the version is already on Foundry — so the workflow now treats it as a warning and succeeds, while still failing on genuine errors. (Confirmed: v0.9 is already registered.)