### PR TITLE
Allow Foundry v13 and v14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A passion project, done in my free time, adapting the content of the incredible
 **An Abundance of Apocrypha** and its expansions — by Nathan Dowdell — to the
 **Wrath & Glory** system (Cubicle 7) for Foundry VTT.
 
-> Compatible with Foundry VTT **v11–v12**. Module id: `wng-apocrypha`.
+> Compatible with Foundry VTT **v11–v14**. Module id: `wng-apocrypha`.
 
 ## Status / Progress
 

--- a/module.json
+++ b/module.json
@@ -5,8 +5,8 @@
   "version": "0.9",
   "compatibility": {
     "minimum": "11",
-    "verified": "11.315",
-    "maximum": "12"
+    "verified": "13",
+    "maximum": "14"
   },
   "authors": [
     {
@@ -26,7 +26,7 @@
         "manifest": "https://github.com/moo-man/WrathAndGlory-FoundryVTT/releases/latest/download/system.json",
         "compatibility": {
           "minimum": "4.0.1",
-          "verified": "4.0.1"
+          "verified": "8.0.0"
         },
         "type": "system"
       }


### PR DESCRIPTION
Makes the module **installable on Foundry v13 and v14**:

- `compatibility`: `verified` 11.315→**13**, `maximum` 12→**14** (the old `maximum: 12` hard-blocked v13).
- `relationships.systems` (wrath-and-glory): `verified` 4.0.1→**8.0.0** (current W&G, which targets v14; the v13 W&G 7.x falls within range).
- All **Actor/Item packs already declare `system: wrath-and-glory`**, satisfying v13's strict requirement that such compendiums declare their system.
- README note v11–v12 → **v11–v14**.

**Manifest-level only.** This makes it install/load on v13/v14. Still recommended on your side: open the module once in a **v13/v14 world with a compatible W&G build**, let Foundry migrate the documents, then `npm run unpack` → `npm run pack` to bake in any schema migration. (No JS code in this module, so v13's ApplicationV2 overhaul doesn't affect it.)