### PR TITLE
Release 1.0 (hold for Foundry validation)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "wng-apocrypha",
   "title": "Wrath and Glory - An Abundance of Apocrypha",
   "description": "A module containing the An Abundance of Apocrypha content for Wrath &amp; Glory System.",
-  "version": "0.9",
+  "version": "1.0",
   "compatibility": {
     "minimum": "11",
     "verified": "13",
@@ -103,5 +103,5 @@
   ],
   "url": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT",
   "manifest": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/latest/module.json",
-  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/MekhanicalUpdate3/wng-apocrypha.zip"
+  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0/wng-apocrypha.zip"
 }


### PR DESCRIPTION
**Do not merge until validated in Foundry.**

Bumps `version` 0.9 → **1.0** and points `download` at the new **`v1.0`** release tag (replacing the `MekhanicalUpdateN` scheme). The `manifest` URL (the moving `latest` release) is unchanged, so Foundry keeps checking the same place.

### What 1.0 contains
The PDF v9 content is fully converted: all 139 archetypes, ascension packages, talents, psychic & Navigator powers, wargear, species, factions, NPCs, companions/familiars, Chapter/Legion options, and **archetype lore journals with stat tables**. Compatible with Foundry **v11–v14**.

### Release steps (after you validate + merge)
1. Merge this PR.
2. Create the GitHub Release tagged **`v1.0`** (target `main`).
3. The [release workflow](.github/workflows/release.yml) then builds `wng-apocrypha.zip`, attaches it + `module.json`, refreshes the `latest` manifest, and registers v1.0 with the Foundry Package Release API (via the `FVTT_RELEASE_TOKEN` secret).

I'll handle steps 2–3 for you once you give the go.