### PR TITLE
Release v1.0.1 (wng-core optional + #37 link fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A passion project, done in my free time, adapting the content of the incredible
 
 > Compatible with Foundry VTT **v11–v14**. Module id: `wng-apocrypha`.
 
+> ⚠️ **Recommended companion — `wng-core` (optional):** the bundled actors link
+> their keywords, talents, weapons and abilities to the official **`wng-core`**
+> content module, and use its icons. `wng-core` is **optional** — this module
+> installs and runs without it — but **without `wng-core` those links won't
+> resolve and many item icons will be missing**. The content is all still there;
+> it just shows up "unlinked". Install `wng-core` for the full, linked experience.
+
 ## Status / Progress
 
 See **[CONVERSION-STATUS.md](CONVERSION-STATUS.md)** for the full, detailed

--- a/module.json
+++ b/module.json
@@ -1,8 +1,8 @@
 {
   "id": "wng-apocrypha",
   "title": "Wrath and Glory - An Abundance of Apocrypha",
-  "description": "A module containing the An Abundance of Apocrypha content for Wrath &amp; Glory System.",
-  "version": "1.0",
+  "description": "A module containing the An Abundance of Apocrypha content for Wrath &amp; Glory System. The optional <b>wng-core</b> module is strongly recommended: without it, item/keyword links and many icons on the bundled actors will not resolve (the content still works, but appears unlinked).",
+  "version": "1.0.1",
   "compatibility": {
     "minimum": "11",
     "verified": "13",
@@ -31,14 +31,12 @@
         "type": "system"
       }
     ],
-    "requires": [
+    "recommends": [
       {
         "id": "wng-core",
         "type": "module",
         "compatibility": {}
-      }
-    ],
-    "recommends": [
+      },
       {
         "id": "wng-forsaken",
         "type": "module"
@@ -109,5 +107,5 @@
   ],
   "url": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT",
   "manifest": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/latest/module.json",
-  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0/wng-apocrypha.zip"
+  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0.1/wng-apocrypha.zip"
 }


### PR DESCRIPTION
Prep for the v1.0.1 release. Reverts `wng-core` to **optional** (recommends) so the module works without it, with a clear disclaimer that links/icons break without it. Bumps version and download tag. Ships the #37 link fix already on main.