### PR TITLE
Release v1.0.2 (@UUID in-text link fix)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "wng-apocrypha",
   "title": "Wrath and Glory - An Abundance of Apocrypha",
   "description": "A module containing the An Abundance of Apocrypha content for Wrath &amp; Glory System. The optional <b>wng-core</b> module is strongly recommended: without it, item/keyword links and many icons on the bundled actors will not resolve (the content still works, but appears unlinked).",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "compatibility": {
     "minimum": "11",
     "verified": "13",
@@ -107,5 +107,5 @@
   ],
   "url": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT",
   "manifest": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/latest/module.json",
-  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0.1/wng-apocrypha.zip"
+  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0.2/wng-apocrypha.zip"
 }


### PR DESCRIPTION
Bumps version to 1.0.2 and download tag to v1.0.2. Ships the @UUID description-link fix (#40 — 1441 in-text links remapped) plus the README/CONVERSION-STATUS refresh. wng-core stays optional with the existing disclaimer.