### PR TITLE
release: point download at v1.0.4 zip

### DIFF
--- a/module.json
+++ b/module.json
@@ -107,5 +107,5 @@
   ],
   "url": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT",
   "manifest": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/latest/module.json",
-  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0.2/wng-apocrypha.zip"
+  "download": "https://github.com/flippelt/WnG-Apocrypha-FoundryVTT/releases/download/v1.0.4/wng-apocrypha.zip"
 }


### PR DESCRIPTION
Bumps the `module.json` `download` URL from the stale `v1.0.2` tag to `v1.0.4`, so the release workflow ships the correct zip. `version` was already at 1.0.4 (from #47/#48); only `download` lagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)